### PR TITLE
Rework some of the autoloader scene-switching and implement tree pausing

### DIFF
--- a/TBD-dragon-game/Global.gd
+++ b/TBD-dragon-game/Global.gd
@@ -7,8 +7,6 @@ var GAME_OVER_SCREEN = "res://gui/GameOverScreen.tscn"
 var OPTIONS_SCREEN = "res://gui/OptionsScreen.tscn"
 var PAUSE_SCREEN = "res://gui/PauseScreen.tscn"
 
-#var options_return = TITLE_SCREEN
-
 var current_scene = null
 
 # Variables for Saving and Loading
@@ -43,12 +41,6 @@ func goto_scene(path: String):
 func _deferred_goto_scene(path):
 	# It is now safe to remove the current scene
 	current_scene.queue_free()
-
-	# which scene options menu should return to
-	#if path == TITLE_SCREEN:
-	#	options_return = TITLE_SCREEN
-	#elif path == PAUSE_SCREEN:
-	#	options_return = PAUSE_SCREEN
 
 	# Load the new scene.
 	var s = ResourceLoader.load(path)

--- a/TBD-dragon-game/Global.gd
+++ b/TBD-dragon-game/Global.gd
@@ -6,15 +6,17 @@ var GAME_OVER_SCREEN = "res://gui/GameOverScreen.tscn"
 var OPTIONS_SCREEN = "res://gui/OptionsScreen.tscn"
 var PAUSE_SCREEN = "res://gui/PauseScreen.tscn"
 
-var options_return = TITLE_SCREEN
+#var options_return = TITLE_SCREEN
 
 var current_scene = null
+
+# Keep track of whether the game is paused
 
 func _ready():
 	var root = get_tree().get_root()
 	current_scene = root.get_child(root.get_child_count() - 1)
 	
-func goto_scene(path):
+func goto_scene(path: String):
 	# This function will usually be called from a signal callback,
 	# or some other function in the current scene.
 	# Deleting the current scene at this point is
@@ -24,18 +26,25 @@ func goto_scene(path):
 	# The solution is to defer the load to a later time, when
 	# we can be sure that no code from the current scene is running:
 
-	call_deferred("_deferred_goto_scene", path)
-
+	# Instancing Pause and Options shouldn't bother
+	# change_scene calls because they always queue_free 
+	# themselves before switching the current_scene node, which in this case
+	# is either the World Node, title screen node, or pause node.
+	if path == PAUSE_SCREEN or path == OPTIONS_SCREEN: 
+		var new_scene = load(path)
+		get_tree().get_root().add_child(new_scene.instance()) 
+	else:
+		call_deferred("_deferred_goto_scene", path)
 
 func _deferred_goto_scene(path):
 	# It is now safe to remove the current scene
 	current_scene.queue_free()
 
 	# which scene options menu should return to
-	if path == TITLE_SCREEN:
-		options_return = TITLE_SCREEN
-	elif path == PAUSE_SCREEN:
-		options_return = PAUSE_SCREEN
+	#if path == TITLE_SCREEN:
+	#	options_return = TITLE_SCREEN
+	#elif path == PAUSE_SCREEN:
+	#	options_return = PAUSE_SCREEN
 
 	# Load the new scene.
 	var s = ResourceLoader.load(path)

--- a/TBD-dragon-game/Global.gd
+++ b/TBD-dragon-game/Global.gd
@@ -20,6 +20,7 @@ func _ready():
 	current_scene = root.get_child(root.get_child_count() - 1)
 	
 func goto_scene(path: String):
+	print(path)
 	# This function will usually be called from a signal callback,
 	# or some other function in the current scene.
 	# Deleting the current scene at this point is
@@ -60,7 +61,13 @@ func _deferred_goto_scene(path):
 
 	# Optionally, to make it compatible with the SceneTree.change_scene() API.
 	get_tree().set_current_scene(current_scene)
-	
+
+func continue_game():
+	call_deferred("_continue_game_helper")
+
+func _continue_game_helper():
+	_deferred_goto_scene(GAME_SCREEN)
+	load_game()
 	
 # Assumes no persist node is under another persist node
 # Call when instantiating a world I guess.
@@ -84,10 +91,8 @@ func load_game():
 	while save_game.get_position() < save_game.get_len():
 		# Get the saved dictionary from the next line in the save file
 		var node_data = parse_json(save_game.get_line())
-
-		# Firstly, we need to create the object and add it to the tree and set its position.
+		# 
 		var new_object = load(node_data["filename"]).instance()
-		get_node(node_data["parent"]).add_child(new_object)
 		new_object.position = Vector2(node_data["pos_x"], node_data["pos_y"])
 
 		# Now we set the remaining variables.
@@ -95,7 +100,7 @@ func load_game():
 			if i == "filename" or i == "parent" or i == "pos_x" or i == "pos_y":
 				continue
 			new_object.set(i, node_data[i])
-
+		get_node(node_data["parent"]).add_child(new_object)
 	save_game.close()
 	print("Loaded!")
 	

--- a/TBD-dragon-game/Global.gd
+++ b/TBD-dragon-game/Global.gd
@@ -1,5 +1,6 @@
 extends Node
 
+# Variables for managing scenes
 var TITLE_SCREEN = "res://gui/TitleScreen.tscn"
 var GAME_SCREEN = "res://scenes/playground/playground_scene.tscn"
 var GAME_OVER_SCREEN = "res://gui/GameOverScreen.tscn"
@@ -10,6 +11,10 @@ var options_return = TITLE_SCREEN
 
 var current_scene = null
 
+# Variables for Saving and Loading
+# TODO
+
+# Functions for managing scenes
 func _ready():
 	var root = get_tree().get_root()
 	current_scene = root.get_child(root.get_child_count() - 1)
@@ -48,4 +53,67 @@ func _deferred_goto_scene(path):
 
 	# Optionally, to make it compatible with the SceneTree.change_scene() API.
 	get_tree().set_current_scene(current_scene)
+	
+	
+# Assumes no persist node is under another persist node
+# Call when instantiating a world I guess.
+func load_game():
+	print("Loading!")
+	var save_game = File.new()
+	if not save_game.file_exists("user://savegame.save"):
+		return # Error! We don't have a save to load.
 
+	# We need to revert the game state so we're not cloning objects
+	# during loading. This will vary wildly depending on the needs of a
+	# project, so take care with this step.
+	# For our example, we will accomplish this by deleting saveable objects.
+	var save_nodes = get_tree().get_nodes_in_group("Persist")
+	for i in save_nodes:
+		i.queue_free()
+
+	# Load the file line by line and process that dictionary to restore
+	# the object it represents.
+	save_game.open("user://savegame.save", File.READ)
+	while save_game.get_position() < save_game.get_len():
+		# Get the saved dictionary from the next line in the save file
+		var node_data = parse_json(save_game.get_line())
+
+		# Firstly, we need to create the object and add it to the tree and set its position.
+		var new_object = load(node_data["filename"]).instance()
+		get_node(node_data["parent"]).add_child(new_object)
+		new_object.position = Vector2(node_data["pos_x"], node_data["pos_y"])
+
+		# Now we set the remaining variables.
+		for i in node_data.keys():
+			if i == "filename" or i == "parent" or i == "pos_x" or i == "pos_y":
+				continue
+			new_object.set(i, node_data[i])
+
+	save_game.close()
+	print("Loaded!")
+	
+# Go through everything in the persist category and ask them to return a
+# dict of relevant variables.
+func save_game():
+	print("Saving...")
+	var save_game = File.new()
+	save_game.open("user://savegame.save", File.WRITE)
+	var save_nodes = get_tree().get_nodes_in_group("Persist")
+	for node in save_nodes:
+		# Check the node is an instanced scene so it can be instanced again during load.
+		if node.filename.empty():
+			print("persistent node '%s' is not an instanced scene, skipped" % node.name)
+			continue
+
+		# Check the node has a save function.
+		if !node.has_method("save"):
+			print("persistent node '%s' is missing a save() function, skipped" % node.name)
+			continue
+
+		# Call the node's save function.
+		var node_data = node.call("save")
+
+		# Store the save dictionary as a new line in the save file.
+		save_game.store_line(to_json(node_data))
+	save_game.close()
+	print("Saved!")

--- a/TBD-dragon-game/entities/player/Player.gd
+++ b/TBD-dragon-game/entities/player/Player.gd
@@ -63,7 +63,8 @@ func take_damage(damage:int):
 	if hit_points <= 0:
 		print("Died!")
 		alive = false
-		emit_signal("death_triggered")
+		# emit_signal("death_triggered") TODO keep as below or fix later
+		Global.goto_scene(Global.GAME_OVER_SCREEN)
 		
 func heal(points:int):
 	print("Healed!")
@@ -74,7 +75,7 @@ func _on_Area2D_body_entered(body):
 		take_damage(body.get("allergy_damage"))
 
 # Copied from https://docs.godotengine.org/en/stable/tutorials/io/saving_games.html
-func save_game(): 
+func save(): 
 	var save_dict = {
 		"filename" : get_filename(),
 		"parent" : get_parent().get_path(),

--- a/TBD-dragon-game/entities/player/Player.gd
+++ b/TBD-dragon-game/entities/player/Player.gd
@@ -72,3 +72,15 @@ func heal(points:int):
 func _on_Area2D_body_entered(body):
 	if not body.get("allergy_damage") == null:
 		take_damage(body.get("allergy_damage"))
+
+# Copied from https://docs.godotengine.org/en/stable/tutorials/io/saving_games.html
+func save_game(): 
+	var save_dict = {
+		"filename" : get_filename(),
+		"parent" : get_parent().get_path(),
+		"pos_x" : position.x, # Vector2 is not supported by JSON
+		"pos_y" : position.y,
+		"hit_points" : hit_points,
+		"max_hp" : max_hp
+	}
+	return save_dict

--- a/TBD-dragon-game/entities/player/Player.tscn
+++ b/TBD-dragon-game/entities/player/Player.tscn
@@ -84,7 +84,7 @@ tracks/0/keys = {
 [sub_resource type="RectangleShape2D" id=7]
 extents = Vector2( 31.5, 31 )
 
-[node name="Player" type="KinematicBody2D"]
+[node name="Player" type="KinematicBody2D" groups=["Persist"]]
 script = ExtResource( 2 )
 
 [node name="Sprite" type="Sprite" parent="."]

--- a/TBD-dragon-game/gui/GameOverScreen.gd
+++ b/TBD-dragon-game/gui/GameOverScreen.gd
@@ -5,8 +5,7 @@ func _ready():
 	pass # Replace with function body.
 
 func _on_Try_Again_pressed():
-	#todo
-	pass
+	Global.continue_game()
 
 func _on_Save_and_Exit_pressed():
 	#todo: save

--- a/TBD-dragon-game/gui/OptionsScreen.gd
+++ b/TBD-dragon-game/gui/OptionsScreen.gd
@@ -2,13 +2,7 @@ extends CanvasLayer
 
 # Called when the node enters the scene tree for the first time.
 func _ready():
-	pass # Replace with function body.
+	pause_mode = Node.PAUSE_MODE_PROCESS # Otherwise return button doesn't work
 	
 func _on_Return_pressed():
-	match Global.options_return:
-		Global.TITLE_SCREEN:
-			Global.goto_scene(Global.TITLE_SCREEN)
-		Global.PAUSE_SCREEN:
-			Global.goto_scene(Global.PAUSE_SCREEN)
-		_:
-			print("woops")
+	self.queue_free()

--- a/TBD-dragon-game/gui/PauseScreen.gd
+++ b/TBD-dragon-game/gui/PauseScreen.gd
@@ -9,4 +9,5 @@ func _on_Options_pressed():
 
 func _on_Save_and_Exit_pressed():
 	#todo: save
+	Global.save_game()
 	Global.goto_scene(Global.TITLE_SCREEN)

--- a/TBD-dragon-game/gui/PauseScreen.gd
+++ b/TBD-dragon-game/gui/PauseScreen.gd
@@ -1,12 +1,18 @@
 extends CanvasLayer
 
-#TODO: implement pausing
+func _ready():
+	pause_mode = Node.PAUSE_MODE_PROCESS
+	get_tree().paused = true
+
 func _on_Resume_pressed():
-	Global.goto_scene(Global.GAME_SCREEN)
+	self.queue_free()
+	get_tree().paused = false
 
 func _on_Options_pressed():
 	Global.goto_scene(Global.OPTIONS_SCREEN)
 
 func _on_Save_and_Exit_pressed():
-	#todo: save
+	# Undo pausing or else everything will not work
+	get_tree().paused = false
+	self.queue_free() # cleanup so it doesn't persist as a garbage scene
 	Global.goto_scene(Global.TITLE_SCREEN)

--- a/TBD-dragon-game/gui/TitleScreen.gd
+++ b/TBD-dragon-game/gui/TitleScreen.gd
@@ -14,7 +14,7 @@ func _on_Start_pressed():
 	Global.goto_scene(Global.GAME_SCREEN)
 
 func _on_Continue_pressed():
-	Global.goto_scene(Global.GAME_SCREEN)
+	Global.continue_game()
 
 func _on_Options_pressed():
 	Global.goto_scene(Global.OPTIONS_SCREEN)

--- a/TBD-dragon-game/gui/TitleScreen.gd
+++ b/TBD-dragon-game/gui/TitleScreen.gd
@@ -14,8 +14,7 @@ func _on_Start_pressed():
 	Global.goto_scene(Global.GAME_SCREEN)
 
 func _on_Continue_pressed():
-	#todo
-	pass
+	Global.goto_scene(Global.GAME_SCREEN)
 
 func _on_Options_pressed():
 	Global.goto_scene(Global.OPTIONS_SCREEN)

--- a/TBD-dragon-game/scenes/playground/playground_scene.tscn
+++ b/TBD-dragon-game/scenes/playground/playground_scene.tscn
@@ -13,6 +13,7 @@ script = ExtResource( 4 )
 position = Vector2( -96, -32 )
 
 [node name="sky" type="Sprite" parent="Player"]
+visible = false
 position = Vector2( -32, 40 )
 scale = Vector2( 3.55224, 4.03738 )
 z_index = -1


### PR DESCRIPTION
Initially the autoloader would delete the world scene before switching to the pause scene, and similar things occurred when bringing up something like the options menu. This didn't allow us to pause and resume to what we needed. Therefore, the two menus, options and pause, were reworked to allow them to overlay on top of various screens and queue_free themselves, which allowed us to not delete the world scene, pause its state, and return to gameplay after pausing right where we left off.